### PR TITLE
set Cargo::new as pub to make the cargo util more flexible

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -5,7 +5,7 @@ ext!(def; Cargo);
 
 impl Cargo {
     #[inline]
-    fn new(sub: impl AsRef<OsStr>) -> Self {
+    pub fn new(sub: impl AsRef<OsStr>) -> Self {
         let mut git = Self(Command::new("cargo"));
         git.arg(sub);
         git


### PR DESCRIPTION
将new设置成pub，方便更灵活使用cargo工具，比如想形成如下命令时：
```bash
cargo -C app1 -Z unstable-options build --package app1  --target riscv64gc-unknown-none-elf
```
其中选项`-C app1 -Z  unstable-options` 可以指定 `app1/.cargo/config.toml` 作为build时的配置，但它必须在`build`之前才能生效，遗憾的是`new`当前是`private`的，而其他方法也不能帮助在生成的命令的任意位置插入选项以及参数。